### PR TITLE
Add GitHub workflow for NPM package release

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,25 @@
+name: "Publish NPM Package"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+      - name: Install dependencies
+        run: npm install
+      - name: Build package
+        run: npm run prepack
+      - name: publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_V107}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clitest",
+  "name": "@cli107/clitest",
   "version": "1.0.1",
   "bugs": "https://github.com/4746/clitest/issues",
   "license": "MIT",
@@ -61,6 +61,7 @@
     "/oclif.manifest.json"
   ],
   "oclif": {
+    "scope": "@cli107",
     "bin": "clitest",
     "dirname": "clitest",
     "commands": "./dist/commands",
@@ -81,6 +82,9 @@
       "name": "Cli test",
       "keypath": "./key/windows-signing.pfx"
     }
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "types": "dist/index.d.ts",
   "exports": "./lib/index.js",


### PR DESCRIPTION
A new GitHub workflow file has been added to handle NPM package releases. The package.json file has been amended to reflect the repository scope and ensure correct directory at the time of publishing. Necessary dependencies and building steps are also included in the workflow.